### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tasks/consulate.yml
+++ b/tasks/consulate.yml
@@ -8,7 +8,7 @@
 - name: install deps (Ubuntu)
   apt: >
     pkg={{item}}
-    state=installed
+    state=present
   with_items:
     - python-pip
     - python-dev

--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -7,25 +7,25 @@
     path: "{{ consul_ui_dir }}"
     state: directory
     mode: 0755
-  when: consul_version | version_compare('0.6.1', '<')
+  when: consul_version is version_compare('0.6.1', '<')
 
 - name: download consul ui
   get_url: >
     url={{consul_ui_download}}
     dest={{consul_download_folder}}
   register: consul_ui_was_downloaded
-  when: consul_version | version_compare('0.6.1', '<') and consul_archive_ui_stat.stat.exists == False
+  when: consul_version is version_compare('0.6.1', '<') and consul_archive_ui_stat.stat.exists == False
 
 - name: create ui dir
   file: path={{ consul_ui_dir }} state=directory
-  when: consul_version | version_compare('0.6.1', '<')
+  when: consul_version is version_compare('0.6.1', '<')
 
 - name: copy and unpack ui
   unarchive: >
     src={{ consul_download_folder }}/{{ consul_ui_archive }}
     dest={{ consul_ui_dir }}
     copy=no
-  when: consul_ui_was_downloaded|changed
+  when: consul_ui_was_downloaded is changed
 
 - name: set ownership
   file: >
@@ -34,7 +34,7 @@
     owner={{consul_user}}
     group={{consul_group}}
     recurse=yes
-  when: consul_ui_was_downloaded|changed
+  when: consul_ui_was_downloaded is changed
 
 - name: consul nginx config
   template: >

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
 - name: install deps (Ubuntu)
   apt: >
     pkg={{item}}
-    state=installed
+    state=present
   with_items:
     - unzip
     - jq
@@ -49,7 +49,7 @@
     name={{consul_user}}
     group={{consul_group}}
     system=yes
-  when: consul_group_created|changed
+  when: consul_group_created is changed
 
 - name: create consul directory
   file: >
@@ -92,7 +92,7 @@
     src={{ consul_download_folder }}/{{ consul_archive }}
     dest={{ consul_home }}/bin
     copy=no
-  when: consul_was_downloaded|changed
+  when: consul_was_downloaded is changed
 
 - name: create TLS key
   no_log: True
@@ -137,7 +137,7 @@
     owner={{consul_user}}
     group={{consul_group}}
     recurse=yes
-  when: consul_was_downloaded|changed
+  when: consul_was_downloaded is changed
 
 - name: copy consul upstart script
   template: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,9 @@
 - { include: install-cli.yml, when: consul_install_consul_cli == true }
 - { include: dnsmasq.yml, when: consul_install_dnsmasq == true }
 - { include: consulate.yml, when: consul_install_consulate == true }
-- service: >
-    name=consul
-    state="{{ consul_service_state }}"
-    enabled=yes
+- service:
+    name: consul
+    state: "{{ consul_service_state }}"
+    enabled: yes
   when: consul_manage_service
 - { include: services.yml, when: consul_services is defined and consul_services|length > 0 }

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -1,6 +1,6 @@
 {
 {% if consul_is_ui == true %}
-  {% if consul_version | version_compare('0.6.1', '<') %}
+  {% if consul_version is version_compare('0.6.1', '<') %}
     "ui_dir": "{{ consul_ui_dir }}",
   {% else %}
     "ui": true,


### PR DESCRIPTION
  * Fix 'using tests as filters' deprecation warning
    Change all from this 'result|success' to 'result is
    success' or 'result is not successful', [more info](https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters).

  * Changed state=installed to state=present for apt module as its
    deprecated, [more info](https://docs.ansible.com/ansible/2.5/modules/apt_module.html)

  * Fixed syntax layout in tasks/main.yml

  * Removed extra white space